### PR TITLE
fix(TrayIconModel): fixes call order in _stopwatch 

### DIFF
--- a/src/RestLittle.UI/Models/TrayIconModel.cs
+++ b/src/RestLittle.UI/Models/TrayIconModel.cs
@@ -30,7 +30,7 @@ namespace RestLittle.UI.Models
 		/// <summary>
 		/// Used to control elapsed time that is fed into <see cref="RestingMonitor"/>.
 		/// </summary>
-		private readonly Stopwatch _stopwatch = new Stopwatch();
+		private readonly Stopwatch _stopwatch;
 
 		/// <summary>
 		/// Whether the object is disposed.
@@ -43,6 +43,8 @@ namespace RestLittle.UI.Models
 		/// <param name="restingMonitor">Service that monitors user resting time.</param>
 		public TrayIconModel(IRestingMonitor restingMonitor)
 		{
+			_stopwatch = new Stopwatch();
+
 			_stopwatch.Start();
 			_updater = new RepeatingEvent(UpdateMonitor, _updateInterval);
 			_updater.Start();

--- a/src/RestLittle.UI/Models/TrayIconModel.cs
+++ b/src/RestLittle.UI/Models/TrayIconModel.cs
@@ -30,7 +30,7 @@ namespace RestLittle.UI.Models
 		/// <summary>
 		/// Used to control elapsed time that is fed into <see cref="RestingMonitor"/>.
 		/// </summary>
-		private readonly Stopwatch _stopwatch;
+		private readonly Stopwatch _stopwatch = new Stopwatch();
 
 		/// <summary>
 		/// Whether the object is disposed.
@@ -43,8 +43,6 @@ namespace RestLittle.UI.Models
 		/// <param name="restingMonitor">Service that monitors user resting time.</param>
 		public TrayIconModel(IRestingMonitor restingMonitor)
 		{
-			_stopwatch = new Stopwatch();
-
 			_stopwatch.Start();
 			_updater = new RepeatingEvent(UpdateMonitor, _updateInterval);
 			_updater.Start();

--- a/src/RestLittle.UI/Plumbing/RepeatingEvent.cs
+++ b/src/RestLittle.UI/Plumbing/RepeatingEvent.cs
@@ -60,8 +60,8 @@ namespace RestLittle.UI.Plumbing
 		{
 			while (_running)
 			{
-				_callback();
 				Thread.Sleep(_interval);
+				_callback();
 			}
 		}
 	}


### PR DESCRIPTION
Call order was inverted inside RepeatingEvent, leading to null errors. This fix will avoid such errors, although it may not guarantee it.

Closes #22.