### PR TITLE
fix: let the user choose to run at startup if not refused

### DIFF
--- a/RestLittle.lutconfig
+++ b/RestLittle.lutconfig
@@ -1,6 +1,0 @@
-<LUTConfig Version="1.0">
-  <Repository />
-  <ParallelBuilds>true</ParallelBuilds>
-  <ParallelTestRuns>true</ParallelTestRuns>
-  <TestCaseTimeout>180000</TestCaseTimeout>
-</LUTConfig>

--- a/src/RestLittle.UI/Program.cs
+++ b/src/RestLittle.UI/Program.cs
@@ -46,14 +46,50 @@ public static class Program
 				"Would you like to run this application automatically on startup?",
 				"Run on startup", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
-			if (result == DialogResult.Yes)
-			{
-				Startup.RegisterApplication();
+				if (result == DialogResult.Yes)
+				{
+					Startup.RegisterApplication();
+				} 
+				else
+				{
+					Settings.Default.AskToRegisterForStartup = false;
+					Settings.Default.Save();
+				}
 			}
-
-			Settings.Default.AskToRegisterForStartup = false;
-
-			Settings.Default.Save();
 		}
+	}
+}
+
+public class Startup
+{
+	// The registry key where the startup applications are stored
+	private const string StartupApps = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+
+	// The name of the application
+	private const string AppKey = "TakeABreak";
+
+	/// <summary>
+	/// Register the application to run on startup.
+	/// </summary>
+	public static void RegisterApplication()
+	{
+		using var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(StartupApps, true);
+
+		key.SetValue(AppKey, Application.ExecutablePath);
+	}
+
+	/// <summary>
+	/// Check if the application is registered to run on startup.
+	/// </summary>
+	/// <returns>
+	/// <see cref="true"/> if the application is registered to run on startup; <see cref="false"/> otherwise."
+	/// </returns>
+	public static bool IsRegistered()
+	{
+		using var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(StartupApps, true);
+
+		var value = key.GetValue(AppKey);
+
+		return value == Application.ExecutablePath;
 	}
 }


### PR DESCRIPTION
If the user hasn't said "no", we should ask again. This will happen if the app directory changes, as settings are currently stored in the user profile (we should change this).